### PR TITLE
pango 1.50.7: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/cairo-feedstock/pr9/41e8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/cairo-feedstock/pr9/9a6abc4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/cairo-feedstock/pr9/41e8d4b
+  - https://staging.continuum.io/prefect/fs/cairo-feedstock/pr9/9a6abc4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://ftp.gnome.org/pub/GNOME/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
+  url: https://download.gnome.org/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
   sha256: 0477f369a3d4c695df7299a6989dc004756a7f4de27eecac405c6790b7e3ad33
 
 build:
@@ -80,11 +80,11 @@ test:
     {% endfor %}
 
 about:
-  home: https://pango.gnome.org/
+  home: https://www.gtk.org/docs/architecture/pango
   license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING
-  summary: 'Text layout and rendering engine.'
+  summary: Text layout and rendering engine.
   description: |
     Pango is a library for laying out and rendering of text, with an emphasis
     on internationalization. Pango can be used anywhere that text layout is
@@ -92,7 +92,6 @@ about:
     context of the GTK+ widget toolkit. Pango forms the core of text and font
     handling for GTK+-2.x.
   doc_url: https://docs.gtk.org/Pango/
-  doc_source_url: https://gitlab.gnome.org/GNOME/pango/-/tree/main/docs
   dev_url: https://gitlab.gnome.org/GNOME/pango/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,9 @@ test:
     {% set libs = libs + ["PangoWin32"] %} # [win]
     {% for lib in libs %}
     - test -f $PREFIX/lib/lib{{ lib | lower }}-1.0${SHLIB_EXT}  # [unix]
-    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/bin/{{ lib | lower }}-1.0-0.dll" exit 1  # [win]
+    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`/lib{{ lib | lower }}-1.0${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\{{ lib | lower }}-1.0-0.dll exit 1  # [win]
+    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=exec_prefix --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/bin/{{ lib | lower }}-1.0-0.dll" exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\{{ lib | lower }}-1.0.lib exit 1  # [win]
     - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/{{ lib | lower }}-1.0.lib" exit 1  # [win]
     - test -f $PREFIX/lib/girepository-1.0/{{ lib }}-1.0.typelib    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,12 +42,7 @@ requirements:
     - harfbuzz {{ harfbuzz }}
     - pkg-config
     - gobject-introspection 1.78.1
-    - xorg-libxau  # [not win]
-    - xorg-libxext  # [not win]
-    - xorg-libx11  # [not win]
-    - libxcb  # [not win]
-    - xorg-libxrender  # [not win]
-    - xorg-xorgproto
+    - xorg-xorgproto  # [linux]
   run:
     - cairo >=1.12.10
     - fontconfig >=2.13.0               # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,21 +34,15 @@ requirements:
     - gobject-introspection
     - pthread-stubs
   host:
+    # xorg/xcb/x11 packages comes from cairo.
     - cairo {{ cairo }}
     - fontconfig {{ fontconfig }}               # [not win]
     - freetype {{ freetype }}                   # [not win]
-    - fribidi 1
+    - fribidi {{ fribidi }}
     - glib {{ glib }}
+    - gobject-introspection 1.78.1
     - harfbuzz {{ harfbuzz }}
     - pkg-config
-    - gobject-introspection 1.78.1
-    # xorg/xcb packages are needed for cairo support.
-    - libxcb  # [linux]
-    - xorg-libx11  # [linux]
-    - xorg-libxau  # [linux]
-    - xorg-libxext  # [linux]
-    - xorg-libxrender  # [linux]
-    - xorg-xorgproto  # [linux]
   run:
     - cairo >=1.12.10
     - fontconfig >=2.13.0               # [not win]
@@ -72,9 +66,7 @@ test:
     {% set libs = libs + ["PangoWin32"] %} # [win]
     {% for lib in libs %}
     - test -f $PREFIX/lib/lib{{ lib | lower }}-1.0${SHLIB_EXT}  # [unix]
-    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`/lib{{ lib | lower }}-1.0${SHLIB_EXT}  # [unix]
-    - if not exist %PREFIX%\\Library\\bin\\{{ lib | lower }}-1.0-0.dll exit 1  # [win]
-    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=exec_prefix --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/bin/{{ lib | lower }}-1.0-0.dll" exit 1  # [win]
+    - test -f `pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/bin/{{ lib | lower }}-1.0-0.dll" exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\{{ lib | lower }}-1.0.lib exit 1  # [win]
     - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/{{ lib | lower }}-1.0.lib" exit 1  # [win]
     - test -f $PREFIX/lib/girepository-1.0/{{ lib }}-1.0.typelib    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,12 @@ requirements:
     - harfbuzz {{ harfbuzz }}
     - pkg-config
     - gobject-introspection 1.78.1
+    # xorg/xcb packages are needed for cairo support.
+    - libxcb  # [linux]
+    - xorg-libx11  # [linux]
+    - xorg-libxau  # [linux]
+    - xorg-libxext  # [linux]
+    - xorg-libxrender  # [linux]
     - xorg-xorgproto  # [linux]
   run:
     - cairo >=1.12.10

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 0477f369a3d4c695df7299a6989dc004756a7f4de27eecac405c6790b7e3ad33
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   run_exports:
     # excellent: https://abi-laboratory.pro/tracker/timeline/pango/
@@ -42,12 +42,12 @@ requirements:
     - harfbuzz {{ harfbuzz }}
     - pkg-config
     - gobject-introspection 1.78.1
-    - xorg-libxau
-    - xorg-libxext
-    - xorg-libx11
-    - libxcb
-    - xorg-libxrender
-    - xorg-xproto
+    - xorg-libxau  # [not win]
+    - xorg-libxext  # [not win]
+    - xorg-libx11  # [not win]
+    - libxcb  # [not win]
+    - xorg-libxrender  # [not win]
+    - xorg-xorgproto
   run:
     - cairo >=1.12.10
     - fontconfig >=2.13.0               # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}   # `meson setup` requires this for built-in tests
-    - {{ cdt('libxau-devel') }}           # [linux]
-    - {{ cdt('libxext-devel') }}          # [linux]
-    - {{ cdt('libx11-devel') }}           # [linux]
-    - {{ cdt('libxcb') }}                 # [linux]
-    - {{ cdt('libxrender-devel') }}       # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}   # [linux and (s390x or ppc64le or x86_64)]; needed for cairo support
     - meson >=0.55.3
     - ninja-base
     - pkg-config
@@ -48,6 +42,12 @@ requirements:
     - harfbuzz {{ harfbuzz }}
     - pkg-config
     - gobject-introspection 1.78.1
+    - xorg-libxau
+    - xorg-libxext
+    - xorg-libx11
+    - libxcb
+    - xorg-libxrender
+    - xorg-xproto
   run:
     - cairo >=1.12.10
     - fontconfig >=2.13.0               # [not win]


### PR DESCRIPTION

**Destination channel:** main

### Links

- [PKG-7749](https://anaconda.atlassian.net/browse/PKG-7749) 
- [Upstream repository](https://gitlab.gnome.org/GNOME/pango/)

### Explanation of changes:

- Bump the build number to 2
- Replace CDTs in `build` section with `xorg`/`xcb`/`x11` conda packages in `host` section

### Notes:

- It's an automated migration/rebuild for the `x11_gui_rebuilds` group:

```
  x11_gui_rebuilds:
    stages:
    - stage: 0
      packages:
      - tk
      - libxkbcommon
      - pango
      - at-spi2-core
      - at-spi2-atk
      - tktable
    - stage: 1
      packages:
      - gtk2
      - gtk3
      - gstreamer
      - harfbuzz
      - cairo
    - stage: 2
      packages:
      - qtbase
      - qtsvg
      - qtimageformats
      - qt5compat
      - qtshadertools
      - qttranslations
    - stage: 3
      packages:
      - qtwebchannel
      - qtwebsockets
      - qtdeclarative
      - qttools
    - stage: 4
      packages:
      - pyqt
      - pyside6
      - wxpython
      - pycairo
    - stage: 5
      packages:
      - glew
      - graphviz
      - jasper
      - gobject-introspection
      - librsvg
    - stage: 6
      packages:
      - qtwebengine
      - vtk
      - opencv
      - poppler
    - stage: 7
      packages:
      - portaudio
      - texlive-core
      - seaborn
```


[PKG-7749]: https://anaconda.atlassian.net/browse/PKG-7749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ