### PR TITLE
pango 1.56.4

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,6 +27,7 @@ set ^"MESON_OPTIONS=^
   -Dintrospection=enabled ^
   -Dfontconfig=enabled ^
   -Dfreetype=enabled ^
+  -Dcairo=enabled ^
   -Dsysprof=disabled ^
   -Dlibthai=disabled ^
   -Ddocumentation=false ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,13 +7,6 @@ set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
 
 :: get mixed path (forward slash) form of prefix so host prefix replacement works
 set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
-
-:: By default Meson tries to run glib-mkenums with the %BUILD_PREFIX% Python, which fails.
-:: In order to override this, we need to use a Meson machine file, because otherwise
-:: Meson prioritizes the results from the glib-2.0 pkg-config file, which don't work.
-echo [binaries] >native_file.txt
-echo glib-mkenums = ['%PREFIX%\python.exe', '%LIBRARY_PREFIX%\bin\glib-mkenums'] >>native_file.txt
-
 set "XDG_DATA_DIRS=%XDG_DATA_DIRS%;%LIBRARY_PREFIX%\share"
 
 :: meson options

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,13 @@ set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
 
 :: get mixed path (forward slash) form of prefix so host prefix replacement works
 set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
+
+:: By default Meson tries to run glib-mkenums with the %BUILD_PREFIX% Python, which fails.
+:: In order to override this, we need to use a Meson machine file, because otherwise
+:: Meson prioritizes the results from the glib-2.0 pkg-config file, which don't work.
+echo [binaries] >native_file.txt
+echo glib-mkenums = ['%PREFIX%\python.exe', '%LIBRARY_PREFIX%\bin\glib-mkenums'] >>native_file.txt
+
 set "XDG_DATA_DIRS=%XDG_DATA_DIRS%;%LIBRARY_PREFIX%\share"
 
 :: meson options

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,52 +3,43 @@ setlocal EnableDelayedExpansion
 
 :: set pkg-config path so that host deps can be found
 :: (set as env var so it's used by both meson and during build with g-ir-scanner)
-set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
+set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig"
 
 :: get mixed path (forward slash) form of prefix so host prefix replacement works
 set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
 
-findstr /m "C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib" "%LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
-if %errorlevel%==0 (
-    :: our current glib gio-2.0.pc has zlib dependency set as an absolute path. 
-    powershell -Command "(gc %LIBRARY_LIB%\pkgconfig\gio-2.0.pc) -replace 'Requires:', 'Requires: zlib,' | Out-File -encoding ASCII %LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
-    powershell -Command "(gc %LIBRARY_LIB%\pkgconfig\gio-2.0.pc) -replace 'C:/ci_310/glib_1642686432177/_h_env/Library/lib/z.lib', '' | Out-File -encoding ASCII %LIBRARY_LIB%\pkgconfig\gio-2.0.pc"
-)
+:: By default Meson tries to run glib-mkenums with the %BUILD_PREFIX% Python, which fails.
+:: In order to override this, we need to use a Meson machine file, because otherwise
+:: Meson prioritizes the results from the glib-2.0 pkg-config file, which don't work.
+echo [binaries] >native_file.txt
+echo glib-mkenums = ['%PREFIX%\python.exe', '%LIBRARY_PREFIX%\bin\glib-mkenums'] >>native_file.txt
 
-:: configure build using meson
-:: https://gitlab.gnome.org/GNOME/pango/-/blob/1.50.7/meson.build
-meson setup builddir ^
+set "XDG_DATA_DIRS=%XDG_DATA_DIRS%;%LIBRARY_PREFIX%\share"
+
+:: meson options
+:: (set pkg_config_path so deps in host env can be found)
+set ^"MESON_OPTIONS=^
   --prefix="%LIBRARY_PREFIX_M%" ^
   --wrap-mode=nofallback ^
   --buildtype=release ^
   --backend=ninja ^
-  -Dgtk_doc=false ^
-  -Dinstall-tests=false ^
-  -Dfontconfig=disabled ^
-  -Dsysprof=disabled ^
-  -Dlibthai=disabled ^
-  -Dcairo=enabled ^
-  -Dxft=disabled ^
-  -Dfreetype=disabled ^
-  -Dintrospection=disabled
-meson setup builddir !MESON_OPTIONS!
+  --native-file=native_file.txt ^
+  -Dintrospection=enabled ^
+  -Dfontconfig=enabled ^
+  -Dfreetype=enabled ^
+  -Ddocumentation=false ^
+ ^"
+
+:: configure build using meson
+%BUILD_PREFIX%\Scripts\meson setup builddir !MESON_OPTIONS!
 if errorlevel 1 exit 1
 
 :: print results of build configuration
-meson configure builddir
+%BUILD_PREFIX%\Scripts\meson configure builddir
 if errorlevel 1 exit 1
 
-:: build
 ninja -v -C builddir -j %CPU_COUNT%
 if errorlevel 1 exit 1
 
-:: test
-ninja -v -C builddir test
-@REM Few errors there, so ignore test result for now
-@REM if errorlevel 1 exit 1
-
-:: install
 ninja -C builddir install -j %CPU_COUNT%
 if errorlevel 1 exit 1
-
-del %LIBRARY_PREFIX%\bin\*.pdb

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,6 +27,8 @@ set ^"MESON_OPTIONS=^
   -Dintrospection=enabled ^
   -Dfontconfig=enabled ^
   -Dfreetype=enabled ^
+  -Dsysprof=disabled ^
+  -Dlibthai=disabled ^
   -Ddocumentation=false ^
  ^"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -xeo pipefail
+
+# Replace host g-ir-scanner with wrapper that runs build scanner with build python
+mv -v "${PREFIX}/bin/g-ir-scanner" "${PREFIX}/bin/g-ir-scanner.real"
+
+cat > "${PREFIX}/bin/g-ir-scanner" <<EOF
+#!/usr/bin/env bash
+exec "${BUILD_PREFIX}/bin/python" "${BUILD_PREFIX}/bin/g-ir-scanner" "\$@"
+EOF
+chmod +x "${PREFIX}/bin/g-ir-scanner"
 
 if [[ "$target_platform" = osx-* ]] ; then
     # The -dead_strip_dylibs option breaks g-ir-scanner in this package: the
@@ -34,6 +43,8 @@ meson_config_args=(
 export DESTDIR="/"
 
 meson setup builddir \
+    --prefix="$PREFIX" \
+    --backend=ninja \
     ${MESON_ARGS} \
     "${meson_config_args[@]}" \
     --wrap-mode=nofallback

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,6 +36,8 @@ meson_config_args=(
     -Dintrospection=enabled
     -Dfontconfig=enabled
     -Dfreetype=enabled
+    -Dsysprof=disabled
+    -Dlibthai=disabled
     -Dgtk_doc=false
 )
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-set -ex
-
-# ppc64le cdt need to be rebuilt with files in powerpc64le-conda-linux-gnu instead of powerpc64le-conda_cos7-linux-gnu. In the meantime:
-if [ "$(uname -m)" = "ppc64le" ]; then
-  cp --force --archive --update --link $BUILD_PREFIX/powerpc64le-conda_cos7-linux-gnu/. $BUILD_PREFIX/powerpc64le-conda-linux-gnu
-fi
+set -xeo pipefail
 
 if [[ "$target_platform" = osx-* ]] ; then
     # The -dead_strip_dylibs option breaks g-ir-scanner in this package: the
@@ -14,92 +9,33 @@ if [[ "$target_platform" = osx-* ]] ; then
     # "ERROR: can't resolve libraries to shared libraries: ...".
     export LDFLAGS="$(echo $LDFLAGS |sed -e "s/-Wl,-dead_strip_dylibs//g")"
     export LDFLAGS_LD="$(echo $LDFLAGS_LD |sed -e "s/-dead_strip_dylibs//g")"
-    rm -rf ${PREFIX}/lib/libuuid*.a ${PREFIX}/lib/libuuid*.la
 fi
 
-# necessary to ensure the gobject-introspection-1.0 pkg-config file gets found
-export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:${PREFIX}/lib/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/lib64/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/share/pkgconfig"
-export PKG_CONFIG=$PREFIX/bin/pkg-config
-declare -a meson_extra_opts
+# get meson to find pkg-config when cross compiling
+export PKG_CONFIG=$BUILD_PREFIX/bin/pkg-config
 
-# Use a sledgehammer to avoid libtool `.la` files when linking; this must be
-# done because various packages  we depend on (e.g., libxml2) no longer have
-# libtool `.la` files within them.
-find "${PREFIX}/lib" -type f -name "*.la" -delete
-
-# The "fribidi" recipe moves shared libraries out of `lib64` into `lib`, but
-# some builds do not properly account for this in their pkg-config files.
-sed -i.bak "s:/lib64:/lib:" "${PREFIX}/lib/pkgconfig/fribidi.pc"
-
-# We must avoid very long shebangs here.
-echo '#!/usr/bin/env bash' > g-ir-scanner
-echo "${PREFIX}/bin/python ${PREFIX}/bin/g-ir-scanner \$*" >> g-ir-scanner
-chmod +x ./g-ir-scanner
-export PATH=${PWD}:${PATH}
-
-mkdir -p builddir
-
-declare -a configure_extra_opts
-case "${target_platform}" in
-    linux-*)
-        configure_extra_opts+=(-Dintrospection=enabled)
-        ;;
-    osx-*)
-        configure_extra_opts+=(-Dintrospection=enabled)
-
-        # Use conda- (not Apple XCode-provided) object & library manipulation
-        # tools; not doing so will cause the build to fail with "malformed
-        # object" & "load command size is zero" errors when building on systems
-        # with older releases of Xcode (e.g., Xcode 7 on OS X 10.10).
-        ln -s "${INSTALL_NAME_TOOL}" "${BUILD_PREFIX}/bin/install_name_tool"
-        ln -s "${NM}" "${BUILD_PREFIX}/bin/nm"
-        ln -s "${OTOOL}" "${BUILD_PREFIX}/bin/otool"
-        hash -r
-        ;;
-esac
+# need to find gobject-introspection-1.0 as a "native" (build) pkg-config dep
+# meson uses PKG_CONFIG_PATH to search when not cross-compiling and
+# PKG_CONFIG_PATH_FOR_BUILD when cross-compiling,
+# so add the build prefix pkgconfig path to the appropriate variables
+export PKG_CONFIG_PATH_FOR_BUILD=$BUILD_PREFIX/lib/pkgconfig
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BUILD_PREFIX/lib/pkgconfig
 
 export XDG_DATA_DIRS=${XDG_DATA_DIRS}:$PREFIX/share
+
+meson_config_args=(
+    -Dintrospection=enabled
+    -Dfontconfig=enabled
+    -Dfreetype=enabled
+    -Dgtk_doc=false
+)
+
 # ensure that the post install script is ignored
 export DESTDIR="/"
 
-meson setup \
-    --prefix="${PREFIX}" \
-    --libdir="${PREFIX}/lib" \
-    --wrap-mode=nofallback \
-    --buildtype=release \
-    --backend=ninja \
-    -Dgtk_doc=false \
-    -Dinstall-tests=false \
-    -Dfontconfig=enabled \
-    -Dsysprof=disabled \
-    -Dlibthai=disabled \
-    -Dcairo=enabled \
-    -Dxft=auto \
-    -Dfreetype=enabled \
-    ${configure_extra_opts[@]} \
-    builddir
-
-# Print build configuration results
-meson configure builddir
-
-# Build
-ninja -C builddir -j ${CPU_COUNT} -v
-
-# Test
-case "${target_platform}" in
-    osx-*)
-        # Requires third-party font (Cantarell), so ignore test results for now
-        ninja -C builddir -j ${CPU_COUNT} test || true
-        ;;
-    linux-*)
-        # Multiple errors there, so ignore test results for now
-        ninja -C builddir -j ${CPU_COUNT} test || true
-        ;;
-esac
-
-# Install
-ninja -C builddir -j ${CPU_COUNT} install
-
-# Remove any new Libtool files we may have installed. It is intended that
-# conda-build will eventually do this automatically.
-find "${PREFIX}/lib" -name "*.la" -delete
+meson setup builddir \
+    ${MESON_ARGS} \
+    "${meson_config_args[@]}" \
+    --wrap-mode=nofallback
+ninja -v -C builddir -j ${CPU_COUNT}
+ninja -C builddir install -j ${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,6 +36,7 @@ meson_config_args=(
     -Dintrospection=enabled
     -Dfontconfig=enabled
     -Dfreetype=enabled
+    -Dcairo=enabled
     -Dsysprof=disabled
     -Dlibthai=disabled
     -Dgtk_doc=false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler:                    # [win]
-- vs2019                       # [win]
-cxx_compiler:                  # [win]
-- vs2019                       # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,4 @@
-harfbuzz:
-  - 10
+c_compiler:                    # [win]
+- vs2019                       # [win]
+cxx_compiler:                  # [win]
+- vs2019                       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,69 +1,57 @@
-{% set major = "1.50" %}
-{% set patch = "7" %}
-{% set version = major + "." + patch %}
+{% set name = "pango" %}
+{% set version = "1.56.4" %}
+{% set version_majmin = ".".join(version.split(".", 2)[:2]) %}
 
 package:
-  name: pango
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://download.gnome.org/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
-  sha256: 0477f369a3d4c695df7299a6989dc004756a7f4de27eecac405c6790b7e3ad33
+  url: https://download.gnome.org/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
+  sha256: 17065e2fcc5f5a5bdbffc884c956bfc7c451a96e8c4fb2f8ad837c6413cb5a01
 
 build:
-  number: 2
+  number: 0
   detect_binary_files_with_prefix: true
   run_exports:
-    # excellent: https://abi-laboratory.pro/tracker/timeline/pango/
-    - {{ pin_subpackage('pango') }}
-  missing_dso_whitelist:         # [linux]
-    - '**/libc.so.6'             # [linux]
-    - '**/libm.so.6'             # [linux]
-  ignore_run_exports:
-    - libcxx          # [osx]
-    - libstdcxx-ng    # [linux]
-    - pixman
+    - {{ pin_subpackage('pango', max_pin='x.x') }}
 
 requirements:
   build:
+    - meson >=1.2.0
+    - ninja
+    - pkg-config
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}   # `meson setup` requires this for built-in tests
-    - meson >=0.55.3
-    - ninja-base
-    - pkg-config
+    - {{ stdlib("c") }}
+    - {{ compiler('cxx') }}
     - gobject-introspection
-    - pthread-stubs
   host:
-    # xorg/xcb/x11 packages comes from cairo.
-    - cairo {{ cairo }}
-    - fontconfig {{ fontconfig }}               # [not win]
-    - freetype {{ freetype }}                   # [not win]
-    - fribidi {{ fribidi }}
+    # core (required)
     - glib {{ glib }}
-    - gobject-introspection 1.78.1
+    - fribidi {{ fribidi }}
     - harfbuzz {{ harfbuzz }}
-    - pkg-config
-  run:
-    - cairo >=1.12.10
-    - fontconfig >=2.13.0               # [not win]
-    - freetype                          # [not win]
-    - fribidi >=1.0.6
-    - glib >=2.62
-    - harfbuzz >=2.6.0
+    # font backends
+    - fontconfig {{ fontconfig }}  # [linux]
+    - freetype {{ freetype }}
+    # cairo backend (required if you ship PangoCairo)
+    - cairo {{ cairo }}
+    - libpng {{ libpng }}
+    # introspection artifacts on target
+    - gobject-introspection 1.*
+    # misc/proto/header deps often needed in linux build envs
+    - xorg-xorgproto  # [linux]
+    - zlib {{ zlib }}
 
 test:
   requires:
     - pkg-config
   commands:
-    - pango-list --help
     - pango-view --help
-    # Ensure gobject introspection data got built
-    - test -f $PREFIX/share/gir-1.0/Pango-1.0.gir # [not win]
+    - pkg-config --exists pango
+
     # check that libraries are installed and can be found through pkg-config
     # (used by downstream builds)
-    {% set libs = ["Pango", "PangoCairo"] %}
-    {% set libs = libs + ["PangoFT2"] %}   # [unix]
-    {% set libs = libs + ["PangoWin32"] %} # [win]
+    {% set libs = ["Pango", "PangoCairo", "PangoFT2"] %}
     {% for lib in libs %}
     - test -f $PREFIX/lib/lib{{ lib | lower }}-1.0${SHLIB_EXT}  # [unix]
     - test -f `pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`/lib{{ lib | lower }}-1.0${SHLIB_EXT}  # [unix]
@@ -72,12 +60,12 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\{{ lib | lower }}-1.0.lib exit 1  # [win]
     - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ lib | lower }}`) do if not exist "%%a/{{ lib | lower }}-1.0.lib" exit 1  # [win]
     - test -f $PREFIX/lib/girepository-1.0/{{ lib }}-1.0.typelib    # [unix]
+    - if not exist %PREFIX%\\Library\\lib\\girepository-1.0\\{{ lib }}-1.0.typelib exit 1  # [win]
     {% endfor %}
 
 about:
   home: https://www.gtk.org/docs/architecture/pango
-  license: GPL-2.0-or-later
-  license_family: GPL
+  license: LGPL-2.1-or-later
   license_file: COPYING
   summary: Text layout and rendering engine.
   description: |
@@ -86,8 +74,8 @@ about:
     needed, though most of the work on Pango so far has been done in the
     context of the GTK+ widget toolkit. Pango forms the core of text and font
     handling for GTK+-2.x.
-  doc_url: https://docs.gtk.org/Pango/
-  dev_url: https://gitlab.gnome.org/GNOME/pango/
+  doc_url: https://www.gtk.org/docs/architecture/pango
+  dev_url: https://gitlab.gnome.org/GNOME/pango
 
 extra:
   recipe-maintainers:
@@ -95,4 +83,3 @@ extra:
     - ccordoba12
     - jakirkham
     - pkgw
-    - chenghlee

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   number: 0
   detect_binary_files_with_prefix: true
+  ignore_run_exports_from:
+    - {{ compiler('cxx') }}
   run_exports:
     - {{ pin_subpackage('pango', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - fribidi {{ fribidi }}
     - harfbuzz {{ harfbuzz }}
     # font backends
-    - fontconfig {{ fontconfig }}  # [unix]
+    - fontconfig {{ fontconfig }}
     - freetype {{ freetype }}
     # cairo backend (required if you ship PangoCairo)
     - cairo {{ cairo }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   detect_binary_files_with_prefix: true
   run_exports:
-    - {{ pin_subpackage('pango', max_pin='x.x') }}
+    - {{ pin_subpackage('pango', max_pin='x') }}
 
 requirements:
   build:
@@ -65,7 +65,7 @@ test:
 
 about:
   home: https://www.gtk.org/docs/architecture/pango
-  license: LGPL-2.1-or-later
+  license: LGPL-2.0-or-later
   license_file: COPYING
   summary: Text layout and rendering engine.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     # introspection artifacts on target
     - gobject-introspection 1.*
     # misc/proto/header deps often needed in linux build envs
-    - xorg-xorgproto  # [linux]
+    - xorg-xorgproto {{ xorg_xorgproto }}  # [linux]
     - zlib {{ zlib }}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ source:
 build:
   number: 0
   detect_binary_files_with_prefix: true
-  ignore_run_exports_from:
-    - {{ compiler('cxx') }}
   run_exports:
     - {{ pin_subpackage('pango', max_pin='x.x') }}
 
@@ -33,7 +31,7 @@ requirements:
     - fribidi {{ fribidi }}
     - harfbuzz {{ harfbuzz }}
     # font backends
-    - fontconfig {{ fontconfig }}  # [linux]
+    - fontconfig {{ fontconfig }}  # [unix]
     - freetype {{ freetype }}
     # cairo backend (required if you ship PangoCairo)
     - cairo {{ cairo }}


### PR DESCRIPTION
pango 1.56.4

**Destination channel:** {defaults}

### Links

- [{PKG-11356}](https://anaconda.atlassian.net/browse/PKG-11356) 
Project Feedstock URL: https://github.com/AnacondaRecipes/pango-feedstock
Project Home URL: https://www.gtk.org/docs/architecture/pango
Project Dev URL: https://gitlab.gnome.org/GNOME/pango/
conda-forge | https://github.com/conda-forge/pango-feedstock

### Explanation of changes:

- version updated 1.50.7 → 1.56.4
- build number reset 2 → 0
- added detect_binary_files_with_prefix: true
- upd run_exports pin for pango subpackage
- upd meson pin and added gobject-introspection
- upd host deps
- added pango-list/pango-view smoke tests and checks for .gir/.typelib and lib/pkgconfig files
- enabled introspection
- wrapped g-ir-scanner
- upd doc_url/dev_url and normalized home URL
